### PR TITLE
Fix reference to towers_any_list in towers method

### DIFF
--- a/keymasters_keep/sanctum_game.py
+++ b/keymasters_keep/sanctum_game.py
@@ -229,7 +229,7 @@ class SanctumGame(Game):
         return ["Ampfield", "Killing Floor", "Slowfield"]
 
     def towers(self, anti_air: bool = True, floors: bool = True) -> list[str]:
-        towers: list[str] = list(self.towers_any)
+        towers: list[str] = list(self.towers_any_list)
         if anti_air:
             towers.extend(self.towers_anti_air_list)
         if floors:


### PR DESCRIPTION
Replaces the incorrect reference to self.towers_any with self.towers_any_list in the towers method to ensure the correct list of towers is used.